### PR TITLE
types(useConvexQuery): `args` required when truly necessary only

### DIFF
--- a/src/composables/useConvexHttpQuery.ts
+++ b/src/composables/useConvexHttpQuery.ts
@@ -2,7 +2,6 @@ import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex
 import type { MaybeRefOrGetter } from 'vue'
 import { ConvexHttpClient } from 'convex/browser'
 import { toValue } from 'vue'
-
 import { useConvexClient } from './useConvexClient'
 
 /**

--- a/src/composables/useConvexMutation.ts
+++ b/src/composables/useConvexMutation.ts
@@ -1,7 +1,6 @@
 import type { OptimisticUpdate } from 'convex/browser'
 import type { FunctionArgs, FunctionReference } from 'convex/server'
 import type { MaybeRefOrGetter } from 'vue'
-
 import { computed, ref, toValue } from 'vue'
 import { useConvexClient } from './useConvexClient'
 

--- a/src/composables/useConvexQuery.ts
+++ b/src/composables/useConvexQuery.ts
@@ -1,20 +1,15 @@
+import type { OptionalRestArgsOrSkip } from '#src/types.ts'
 import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
-import type { MaybeRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { MaybeRef, Ref } from 'vue'
 import {
   getFunctionName,
 } from 'convex/server'
-
 import { computed, onScopeDispose, ref, toValue, watch } from 'vue'
 import { useConvexClient } from './useConvexClient'
-
-export type { ComputedRef, MaybeRef, MaybeRefOrGetter } from 'vue'
 
 export interface UseConvexQueryOptions {
   enabled?: MaybeRef<boolean>
 }
-
-export type EmptyObject = Record<string, never>
-export type OptionalRestArgsOrSkip<FuncRef extends FunctionReference<any>> = FuncRef['_args'] extends EmptyObject ? [args?: EmptyObject | undefined] : [args: MaybeRefOrGetter<FuncRef['_args']>]
 
 export function useConvexQuery<Query extends FunctionReference<'query'>>(query: Query, ...args: OptionalRestArgsOrSkip<Query>) {
   const convex = useConvexClient()

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,6 @@ export { useConvexClient } from './composables/useConvexClient'
 export { useConvexHttpQuery } from './composables/useConvexHttpQuery'
 export { useConvexMutation } from './composables/useConvexMutation'
 export { useConvexQuery } from './composables/useConvexQuery'
+
 export * from './plugin'
+export * from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+import type { FunctionReference } from 'convex/server'
+import type { MaybeRefOrGetter } from 'vue'
+
+export type IsOptionalKey<T, K extends keyof T> =
+  object extends Pick<T, K> ? true : false
+
+export type AreAllPropertiesOptional<T> =
+  true extends {
+    [K in keyof T]: IsOptionalKey<T, K> extends true ? never : true
+  }[keyof T]
+    ? false
+    : true
+
+export type OptionalRestArgsOrSkip<FuncRef extends FunctionReference<any>> = AreAllPropertiesOptional<FuncRef['_args']> extends true
+  ? [args?: MaybeRefOrGetter<FuncRef['_args']>]
+  : [args: MaybeRefOrGetter<FuncRef['_args']>]


### PR DESCRIPTION
This improves DX / fixes a probably unwanted types-breaking from #17 where `args` is required even on all optional args.

I also moved the `utils`-ish types to `src/types.ts`